### PR TITLE
Update lets_encrypt.rst

### DIFF
--- a/source/getting_started/lets_encrypt.rst
+++ b/source/getting_started/lets_encrypt.rst
@@ -163,7 +163,7 @@ Paste the code below into the file
  }
 
  location ~ \.php$ {
-   fastcgi_pass unix:/var/run/php5-fpm.sock;
+   fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
    #fastcgi_pass 127.0.0.1:9000;
    fastcgi_index index.php;
    include fastcgi_params;


### PR DESCRIPTION
With the install script, it will install php 7.1.

nginx won't restart if it's still using php5