### PR TITLE
Set renewal cron job to daily

### DIFF
--- a/source/getting_started/lets_encrypt.rst
+++ b/source/getting_started/lets_encrypt.rst
@@ -93,10 +93,10 @@ Crontab can be used to renew let's encrypt.
 
  Create crontab -e
  
- 0 0 9 JAN-DEC * /usr/bin/certbot renew &>/var/log/fusionpbx_certbot.cronlog
+ 2 3 * * * /usr/bin/certbot renew &>/var/log/fusionpbx_certbot.cronlog
  
 
-This executes every month on the 9th at midnight
+This executes daily at 3:02 AM (local time).  Certbot will check your existing certificate.  If it has less than 30 days' validity remaining, it will attempt to renew the certificate.  It runs daily in case a renewal attempt fails, it will just try again the next day.
  
 
 **List crontabs**


### PR DESCRIPTION
Let's Encrypt recommend that the `certbot renew` be run daily, or even twice daily.  There's no danger of hitting the rate limits with a properly-configured system, as certbot checks your existing cert first and only attempts renewal if it's valid for less than 30 more days at the time the command runs.