### PR TITLE
Update Transcription API Docs

### DIFF
--- a/source/applications/voicemail.rst
+++ b/source/applications/voicemail.rst
@@ -13,7 +13,7 @@ Here you can edit voicemail settings.
 
 *  Play Tutorial- Play the voicemail tutorial after the next voicemail login
 *  Greeting- When you dial ***97**, record a greeting and set a number you can choose which greeting to use
-*  Alternate Greet ID- An alternative greet id used in the default greeting 
+*  Alternate Greet ID- An alternative greet id used in the default greeting
 *  Options- Define caller options for the voicemail greeting
 *  Mail to- have voicemails emailed to this address
 *  Voicemail File- Select a listening option to include with the email notification
@@ -26,7 +26,7 @@ Here you can edit voicemail settings.
 
 .. note::
 
- Starting version 4.2 remote access to voicemail by interupting the greeting message by pressing "*" and entering the password is disabled by default.
+ Starting version 4.2 remote access to voicemail by interrupting the greeting message by pressing "*" and entering the password is disabled by default.
 
 To enable remote access to voicemail
 
@@ -101,13 +101,13 @@ These variables can be set in advanced -> variables or in the dialplan.
 +---------------------------+----------------+
 | vm_disk_quota             | 0-3600 seconds |
 +---------------------------+----------------+
-| vm_message_ext            | wav or mp3     | 
+| vm_message_ext            | wav or mp3     |
 +---------------------------+----------------+
-| voicemail_authorized      | true or false  | 
+| voicemail_authorized      | true or false  |
 +---------------------------+----------------+
-| vm_say_caller_id_number   | true or false  | 
+| vm_say_caller_id_number   | true or false  |
 +---------------------------+----------------+
-| vm_say_date_time          | true or false  | 
+| vm_say_date_time          | true or false  |
 +---------------------------+----------------+
 
 Wav file is the default voicemail message file type.
@@ -126,40 +126,7 @@ Voicemail Transcription
 
 |
 
-Uses API services to transcribe voicemails into text to be used in the app-sms and the voicemail to email options.
-
-The following services are supported. Others can be added but would need to be developed.
-
-*  Microsoft Bing
-Sign up and language information is located on `Microsoft Site <https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceRecognition>`_
-
-.. warning:: We cannot use mod_shout to record Voicemails because the transcription service needs an uncompressed version of the audio. Therefore we will record in WAV and then use LAME to re-encode in MP3. This could cause added resource utilization to your system.
-
-**Goto Advanced > Default Settings.**
-Add the following entries
-
-+-------------+-----------------------+-----------+---------------------------+-----------+
-|  Category   |  Subcategory          |  Type     |  Value                    |  Enabled  |
-+=============+=======================+===========+===========================+===========+
-|  voicemail  |  transcribe_provider  |  text     |  microsoft                |  True     |
-+-------------+-----------------------+-----------+---------------------------+-----------+
-|  voicemail  |  microsoft_key1       |  text     |  {your microsoft key #1}  |  True     |
-+-------------+-----------------------+-----------+---------------------------+-----------+
-|  voicemail  |  microsoft_key2       |  text     |  {your microsoft key #2}  |  True     |
-+-------------+-----------------------+-----------+---------------------------+-----------+
-|  voicemail  |  transcribe_language  |  text     |  en-US                    |  True     |
-+-------------+-----------------------+-----------+---------------------------+-----------+
-|  voicemail  |  transcribe_enabled   |  boolean  |  true                     |  True     |
-+-------------+-----------------------+-----------+---------------------------+-----------+
- 
- Click "Reload" at the top of the page.
- 
-**Goto Status > Sip Status.**
-
-Click "Flush Memcache", "Reload XML" and "Rescan".
- 
-If you entered your key's correctly, you should now start getting transcriptions delivered in your voicemail to email and you will also see them on the Messages page.
-
+FusionPBX supports Voicemail Transcription, where emails will include a transcribed version of the voicemail the email was sent in regards to. To configure this feature, see applications/voicemail_transcription.rst.
 
 
 .. _Voicemail Default Settings: /en/latest/advanced/default_settings.html#id32

--- a/source/applications/voicemail_transcription.rst
+++ b/source/applications/voicemail_transcription.rst
@@ -43,7 +43,7 @@ Custom API
 ====================
 
 
-Initially you will need your API info from the Speech to Text provider of your choice, or you can self host a transcription engine like Mozilla DeepSpeech or Kaldi ASR.
+API info from the Speech to Text provider of your choice is needed, or you can self host a transcription engine like `Mozilla DeepSpeech <https://git.callpipe.com/fusionpbx/deepspeech_frontend>`_ or `Kaldi ASR <https://github.com/dialogflow/asr-server>`_
 
 **Goto Advanced > Default Settings.**
 Add the following entries

--- a/source/applications/voicemail_transcription.rst
+++ b/source/applications/voicemail_transcription.rst
@@ -4,9 +4,13 @@ Voicemail Transcription
 
 |
 
-Uses API services to transcribe voicemails into text to be used in the app-sms and the voicemail to email options. Currently (11/3/16) only supports microsoft bing
+Uses API services to transcribe voicemails into text to be used in the app-sms and the voicemail to email options. Bing's Speech API or other generic APIs can be used.
 
-Sign up and language information is located on `Microsoft Site <https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceRecognition>`_
+Bing API
+====================
+
+
+Sign up and language information is located on `Microsoft Site <https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceRecognition>`_ Note: The Bing Speech API is deprecated as of October 2018, this works for now but needs to be ported to `the new API <https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/how-to-migrate-from-bing-speech.md>`_
 
 .. warning:: We cannot use mod_shout to record Voicemails because the transcription service needs an uncompressed version of the audio. Therefore we will record in WAV and then use LAME to re-encode in MP3. This could cause added resource utilization to your system.
 
@@ -26,11 +30,44 @@ Add the following entries
   +-------------+-----------------------+-----------+---------------------------+-----------+
   |  voicemail  |  transcribe_enabled   |  boolean  |  true                     |  True     |
   +-------------+-----------------------+-----------+---------------------------+-----------+
- 
+
  Click "Reload" at the top of the page.
- 
+
 **Goto Status > Sip Status.**
 
 Click "Flush Memcache", "Reload XML" and "Rescan".
- 
+
+If you entered your key's correctly, you should now start getting transcriptions delivered in your voicemail to email and you will also see them on the Messages page.
+
+Custom API
+====================
+
+
+Initially you will need your API info from the Speech to Text provider of your choice, or you can self host a transcription engine like Mozilla DeepSpeech or Kaldi ASR.
+
+**Goto Advanced > Default Settings.**
+Add the following entries
+
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  Category   |  Subcategory          |  Type     |  Value                    |  Enabled  |  Required?  |
+  +=============+=======================+===========+===========================+===========+=============+
+  |  voicemail  |  transcribe_provider  |  text     |  custom                   |  True     |             |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  voicemail  |  transcription_server |  text     |  https://yourserver 	    |  True     |             |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  voicemail  |  json_enabled         |  boolean  |  true                     |  True     |  Optional   |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  voicemail  |  api_key              | text      |  your_api_key             |  True     |  Optional   |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  voicemail  |  transcribe_language  |  text     |  en-US                    |  True     |             |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+  |  voicemail  |  transcribe_enabled   |  boolean  |  true                     |  True     |             |
+  +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
+
+ Click "Reload" at the top of the page.
+
+**Goto Status > Sip Status.**
+
+Click "Flush Memcache", "Reload XML" and "Rescan".
+
 If you entered your key's correctly, you should now start getting transcriptions delivered in your voicemail to email and you will also see them on the Messages page.

--- a/source/applications/voicemail_transcription.rst
+++ b/source/applications/voicemail_transcription.rst
@@ -53,7 +53,7 @@ Add the following entries
   +=============+=======================+===========+===========================+===========+=============+
   |  voicemail  |  transcribe_provider  |  text     |  custom                   |  True     |             |
   +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
-  |  voicemail  |  transcription_server |  text     |  https://yourserver 	    |  True     |             |
+  |  voicemail  |  transcription_server |  text     |  https://yourserver       |  True     |             |
   +-------------+-----------------------+-----------+---------------------------+-----------+-------------+
   |  voicemail  |  json_enabled         |  boolean  |  true                     |  True     |  Optional   |
   +-------------+-----------------------+-----------+---------------------------+-----------+-------------+


### PR DESCRIPTION
This documents the code added on https://github.com/fusionpbx/fusionpbx/pull/3753

I removed a duplicate copy of the voicemail transcription setup instructions from voicemail.rst and linked from where those instructions were to voicemail_transcription.rst. I also documented the variables Custom API expects, and added links to the Bing Speech API migration guide and two HTTP front-ends that should work for the custom API if one wants to self host a speech transcription server.