### PR TITLE
Add feature_key_sync variables.

### DIFF
--- a/source/applications/call_routing.rst
+++ b/source/applications/call_routing.rst
@@ -42,16 +42,23 @@ Enable Feature Sync on the Device
 
 * Yealink
   
-  *  Web Interface -> Features -> General Information -> Feature Key Synchronization set to Enabled
+  * Web Interface -> Features -> General Information -> Feature Key Synchronization set to Enabled
   * Config Files -> features.feature_key_sync.enable
   * Might be addition settings needed for the latest firmware. I tested with 81.0.110
+  * FusionPBX Default Settings -> Provision -> yealink_feature_key_sync
 
 * Polycom
-  
   * reg.{$row.line_number}.serverFeatureControl.cf="1"
   * reg.{$row.line_number}.serverFeatureControl.dnd="1"
+  * FusionPBX Default Settings -> Provision -> polycom_feature_key_sync
 
 * Cisco SPA
   
   * <Feature_Key_Sync_1_ group="Ext_1/Call_Feature_Settings">Yes</Feature_Key_Sync_1_>
+  * FusionPBX Default Settings -> Provision -> spa_feature_key_sync
+  
+* Grandstream GXP and GRP
+  * Web Interface -> Accounts -> Account X -> SIP Settings -> Advanced Features -> Feature Key Synchronization
+  * Config file P2325
+  * FusionPBX Default Settings -> Provision -> grandstream_feature_key_sync
 


### PR DESCRIPTION
Should we consolidate all of these to the feature_key_sync variable originally proposed? The other default settings have existed for a while.