### PR TITLE
Minor error for the in the provisioning default settings page.

### DIFF
--- a/source/advanced/default_settings/provision.rst
+++ b/source/advanced/default_settings/provision.rst
@@ -5,8 +5,8 @@ Provision
 In the Provisioning section, there are a few key options that have to be set in order to turn auto provisioning on.
 
 * **enabled:** Must be enabled and set to **value true** and **enabled True**.  It is disabled by default.
-* **http_auth_username:** Must be enabled and set to **value true** and **enabled True**.  It is disabled by default. Be sure to use a strong username.
-* **http_auth_password:** Must be enabled and set to **value true** and **enabled True**.  It is disabled by default. Be sure to use a strong password.
+* **http_auth_username:** Must be enabled and set to your desired admin username and **enabled True**.  It is disabled by default. Be sure to use a strong username.
+* **http_auth_password:** Must be enabled and set to your desired admin password and **enabled True**.  It is disabled by default. Be sure to use a strong password.
 
 +---------------------------------------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Default Setting Subcategory                       | Default Setting Name | Default Setting Value                                                                                                                | Default Setting Enabled | Default Setting Description                                                                                                                                                 |


### PR DESCRIPTION
These two lines are incorrect, the value needs to be the desired admin username and password and not 'true'....unless you want true/true as your username/password. 😉