### PR TITLE
Corrections and updates for contributing section.

### DIFF
--- a/source/contributing.md
+++ b/source/contributing.md
@@ -12,9 +12,9 @@ There are many ways to help the FusionPBX project.
 
 :::{note}   
 If you are planning to contribute to any of our GitHub repos, we require that you sign   
-the FusionPBX Contributor License Agreement. This mainly protects FusionPBX and our users **(read: you)**   
+the FusionPBX Contributor License Agreement. This mainly protects FusionPBX and our users
 from code that could be inserted that might pose a legal problem. It does this by verifying the code you're   
-contributing is yours to give and that you give it freely and irrevocably to the project.   
+contributing is yours to give and that you give it freely and irrevocably to the project.
 :::   
 
 ### How to Get Started
@@ -35,13 +35,10 @@ Contributing code or documentation requires knowledge of Git, GitHub, and how to
 This is not as bad as it sounds, and if you are willing to learn, we will help you through it.   
 :::   
 
-### Table of Contents
+```{toctree}
+:maxdepth: 1
 
-- [Contributing Code](contributing/contributing_code.md)
-- [Signing the CLA](contributing/signing_the_cla.md)
-- [Contributing Documentation](contributing/contributing_documentation.md)
-- [Contributing Translations](contributing/contributing_translations.md)
-- [QA Testing](contributing/qa_testing.md)
-- [GitHub Rebase](contributing/github_rebase.md)
-- [Coding Standards](contributing/coding_standards.md)
-<!-- # [Directory Structure](contributing/directory_structure.md) -->
+contributing/sign_the_cla.md
+contributing/github_rebase.md
+contributing/coding_standards.md
+```

--- a/source/contributing/coding_standards.md
+++ b/source/contributing/coding_standards.md
@@ -1,90 +1,69 @@
 # Coding Standards
 
-## **General**
+## General
 
-class, method, function and variable names
+### Class, Method, Function, and Variable Names
+- Intuitive
+- Lower case
+- Words separated with an underscore
+- Do not abbreviate words unless the name becomes excessively long
+- Indentation: use tabs instead of spaces
+- Recommended to code with an editor showing invisible characters to prevent trailing spaces and tabs
 
--   intuitive
--   lower case
--   words separated with an underscore
--   do not abbreviate the words unless it makes the name excessively
-    long.
--   indentation use tabs instead of spaces
--   recommended to code with editor showing invisible characters to
-    prevent trailing spaces and tabs.
+## Applications
 
-## **Applications**
+Apps are stored in the `fusionpbx/app` directory.
 
-Apps are stored in fusionpbx/app directory.
+### root.php
+- Ensures the `document_root` server variable is set and then sets the include path from the root of the website.
 
-**root.php**
+### app_config.php
 
--   Ensures the document[root]{#root} server variable is set and then
-    sets the include path from the root of the website.
+#### Application
+- `app_name`
+- `app_uuid`
+- `app_category`
+- `app_subcategory`
+- `app_description`
 
-**app_config.php**
+#### Menu
+- Defines location in the menu.
 
-**application**
+#### Permissions
+- Defines the permissions the application uses and the default groups assigned to those permissions.
 
--   app[name]{#name}
--   app[uuid]{#uuid}
--   app[category]{#category}
--   app[subcategory]{#subcategory}
--   app[description]{#description}
+#### Data Schema
+- Defines the structure of the field names and types.
 
-**Menu**
+### app_defaults.php
+- Runs during the install and when the upgrade schema is called.
 
--   defines location in the menu.
+### app_languages.php
+- Defines a PHP array of the words, phrases, and sentences used in the project.
 
-**Permissions**
+### Files
+- **Names**
+  - Written in lower case
+  - Words are separated by an underscore
+  - Use full words when possible
+  - Do not prefix with `v_` (files currently prefixed this way will be renamed to remove the `v_`)
+  - Use a program showing invisible spaces
+  - Eliminate tabs and spaces at the end of a line
+  - Use line feed only (no carriage return and line feed)
 
--   Defines the permissions the application uses and the default groups
-    assigned to those permissions.
+## Database
 
-**Data Schema**
+### Tables
+- Prefixed with `v_` (this may be configurable in the future)
+- Table names are plural unless the name is an acronym
+- Use full words, not abbreviations
+- UUIDs used for relational IDs instead of auto-increment identifiers
 
--   Define the structure of the field names, and types.
+### Fields
+- `domain_uuid`
+- Primary key name is the non-plural name of the table without the `v_` prefix
+  - **How to create the primary key name**:
+    - For a table named `v_users`, remove the `v_`, make it non-plural, and add `_uuid` to the end of the field name. In this example, the primary key would be `user_uuid`.
 
-**app_defaults.php**
-
--   Is run during the install and when upgrade schema is called.
-
-**app_languages.php**
-
--   Defines a php array of the words, phrases and sentences used in the
-    project.
-
-**Files**
-
--   Names
-    -   Written in lower case.
-    -   Words are seperated by an underscore.
-    -   Use full words when possible.
-    -   Do not prefix with \'[v]()\' files that are currently prefix in
-        this way will be renamed to remove the \'[v]()\'.
-    -   Program showing invisible spaces.
-    -   To eliminate tabs and spaces at the end of a line.
-    -   Line feed only.
-    -   No carriage return and line feed.
-
-**Database**
-
--   tables
-    -   Prefixed with [v]() this may be configurable in the future.
-    -   Tables names are plural unless the name is used is an Acronym.
-    -   Use full words not abbreviations.
-    -   uuids used for relational id instead of auto increment
-        identifiers.
--   fields
-    -   domain[uuid]{#uuid}
-    -   Primary key name is the non plural name of table without the
-        [v]() prefix.
-        -   How to create the primary key name
-        -   If the table name is v[users]{#users} take remove the
-            \'[v]()\', make it non-plural and add \'[uuid]{#uuid}\' to
-            the end of the field name. In this example the primary key
-            would be user[uuid]{#uuid}
-
-Code Documentation
-
-<http://www.phpdoc.org/>
+## Code Documentation
+[http://www.phpdoc.org/](http://www.phpdoc.org/)

--- a/source/contributing/sign_the_cla.md
+++ b/source/contributing/sign_the_cla.md
@@ -1,0 +1,41 @@
+## Signing The CLA
+
+Hello, Potential Contributor.
+
+We at FusionPBX are excited to collaborate with you, whether you're contributing code, documentation, or translations, in order for us to accept any patches,
+you must electronically sign a statement that indicates two things:
+
+-   You are willingly licensing your contributions under the terms of
+    the open source license of the project that you're contributing to.
+-   You are legally able to license your contributions as stated.
+
+The reason we do this is to ensure, to the extent possible, that we
+don't "taint" the projects we manage with contributions that turn out to
+be improper. This protects everyone who wants to use the projects,
+including *you*! If you want a longer explanation, then you can check
+out the [CLA Rationale](https://github.com/Fusionpbx/opensource/blob/master/cla-rationale.md) Page.
+
+Once you sign the Contributor License Agreement (the "CLA"), we will
+then be able to merge your contributions with a clear conscience and
+with only the friction that results from the usual technical
+back-and-forth of a vibrant open source project.
+
+To get started with this process.
+
+[Sign the CLA](https://github.com/Fusionpbx/opensource/blob/master/sign-cla.md) - [Required]
+
+[CLA Rationale](https://github.com/Fusionpbx/opensource/blob/master/cla-rationale.md) - [Optional if Curious]
+
+[Contributors](https://github.com/Fusionpbx/opensource/blob/master/contributors) - [List of Contributors]
+
+[Contributor License Agreement 2.0](https://github.com/Fusionpbx/opensource/blob/master/cla-2.0.md) - [The Actual CLA]
+
+Thanks, FusionPBX!
+
+### List of Projects
+
+-   [FusionPBX](https://github.com/Fusionpbx/fusionpbx) The Official FusionPBX Repo.
+-   [FusionPBX Apps](https://github.com/Fusionpbx/fusionpbx-apps) Aplications for FusionPBX.
+-   [FusionPBX Scripts](https://github.com/Fusionpbx/fusionpbx-install.sh) Install and Upgrade Scripts for FusionPBX.
+-   [FusionPBX Documents](https://github.com/Fusionpbx/fusionpbx-docs) This site.
+-   [Open Source Umbrella Project](https://github.com/Fusionpbx/opensource) Signed Contributor Licenses Agreements.


### PR DESCRIPTION
Corrected TOC and broken structure, for contributing.md

Condensed the following five pages with repetitive information and structure
into one comprehensive document (contributing/sign_the_cla.md)

/contributing/contributing_code.md
/contributing/contributing_documentation.md
/contributing/contributing_translations.md
/contributing/qa_testing.md
/contributing/signing_the_cla.md

Updating broken structure and links for /contributing/coding_standards.md
